### PR TITLE
Updating var

### DIFF
--- a/src/InputWrapper.js
+++ b/src/InputWrapper.js
@@ -3,7 +3,7 @@ import React from "react";
 export default class InputWrapper extends React.Component {
     render() {
         const {label, styles, children, subtext} = this.props;
-        let i = 0;
+        var i = 0;
         const inputs = React.Children.toArray(children).map((child) =>
             <div className={styles.inputSection} key={i++}>
                 {child}


### PR DESCRIPTION
+ It has been noticed that Safari  > 9.5 does not support let keyword even after using polyfills, so further commits will be for this.