### PR TITLE
Update MortgageCalculator.js

### DIFF
--- a/src/MortgageCalculator.js
+++ b/src/MortgageCalculator.js
@@ -63,7 +63,7 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onPriceChange(e) {
-        let value = e.target.value;
+        var value = e.target.value;
         if (value.length === 0) {
             this.setState({
                 totalPrice: value
@@ -73,10 +73,10 @@ export default class MortgageCalculator extends React.Component {
         value = Util.moneyToValue(value);
         if (isNaN(value)) return;
         this.mortgageCalculator.totalPrice = value;
-        let downPaymentPercent = (this.state.totalPrice > 0) ? this.state.downPayment / this.state.totalPrice : DefaultDownPaymentPercent;
-        let downPayment = downPaymentPercent * value;
+        var downPaymentPercent = (this.state.totalPrice > 0) ? this.state.downPayment / this.state.totalPrice : DefaultDownPaymentPercent;
+        var downPayment = downPaymentPercent * value;
         this.mortgageCalculator.downPayment = downPayment;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             totalPrice: value,
             downPayment: downPayment,
@@ -86,7 +86,7 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onDownPaymentChange(e) {
-        let value = e.target.value;
+        var value = e.target.value;
         if (value.length === 0) {
             this.setState({
                 downPayment: value
@@ -96,7 +96,7 @@ export default class MortgageCalculator extends React.Component {
         value = Util.moneyToValue(value);
         if (isNaN(value)) return;
         this.mortgageCalculator.downPayment = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             downPayment: value,
             mortgage: mortgage
@@ -105,7 +105,7 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onDownPaymentPercentChange(e) {
-        let value = e.target.value;
+        var value = e.target.value;
         if (value.length === 0) {
             this.setState({
                 downPayment: value
@@ -113,9 +113,9 @@ export default class MortgageCalculator extends React.Component {
             return
         }
         if (isNaN(value)) return;
-        let downPayment = Math.round((value / 100) * this.state.totalPrice);
+        var downPayment = Math.round((value / 100) * this.state.totalPrice);
         this.mortgageCalculator.downPayment = downPayment;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             downPayment: downPayment,
             mortgage: mortgage
@@ -124,10 +124,10 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onInterestRateChange(e) {
-        let value = Util.percentToValue(e.target.value);
+        var value = Util.percentToValue(e.target.value);
         if (isNaN(value)) return;
         this.mortgageCalculator.interestRate = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgage: mortgage
         });
@@ -135,10 +135,10 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onTermMonthsChange(e) {
-        let value = e.target.value;
+        var value = e.target.value;
         if (isNaN(value)) return;
         this.mortgageCalculator.months = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgage: mortgage
         });
@@ -146,9 +146,9 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onAdditionalPrincipalChange(e) {
-        let value = Util.moneyToValue(e.target.value);
+        var value = Util.moneyToValue(e.target.value);
         this.mortgageCalculator.additionalPrincipalPayment = !isNaN(value) ? value : 0;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             additionalPrincipal: value,
             mortgage: mortgage
@@ -157,10 +157,10 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onTaxRateChange(e) {
-        let value = Util.percentToValue(e.target.value);
+        var value = Util.percentToValue(e.target.value);
         if (isNaN(value)) return;
         this.mortgageCalculator.taxRate = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgage: mortgage
         });
@@ -168,10 +168,10 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onInsuranceRateChange(e) {
-        let value = Util.percentToValue(e.target.value);
+        var value = Util.percentToValue(e.target.value);
         if (isNaN(value)) return;
         this.mortgageCalculator.insuranceRate = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgage: mortgage
         });
@@ -179,10 +179,10 @@ export default class MortgageCalculator extends React.Component {
     }
 
     onMortgageInsuranceRateChange(e) {
-        let value = Util.percentToValue(e.target.value);
+        var value = Util.percentToValue(e.target.value);
         if (isNaN(value)) return;
         this.mortgageCalculator.mortgageInsuranceRate = value;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgage: mortgage
         });
@@ -191,7 +191,7 @@ export default class MortgageCalculator extends React.Component {
 
     onMortgageInsuranceEnabledChange(e) {
         this.mortgageCalculator.mortgageInsuranceEnabled = e;
-        let mortgage = this.mortgageCalculator.calculatePayment();
+        var mortgage = this.mortgageCalculator.calculatePayment();
         this.setState({
             mortgageInsuranceEnabled: this.mortgageCalculator.mortgageInsuranceEnabled,
             mortgage: mortgage
@@ -205,13 +205,13 @@ export default class MortgageCalculator extends React.Component {
         const {loanAmount, principalAndInterest, tax, insurance, mortgageInsurance, total} = this.state.mortgage;
         const {interestRate, taxRate, insuranceRate, mortgageInsuranceRate, mortgageInsuranceEnabled, months} = this.mortgageCalculator;
         const styles = this.props.styles || DefaultStyles;
-        let paymentCount = this.state.mortgage.paymentSchedule.length;
-        let years = Math.floor(paymentCount / 12);
-        let remainingMonths = paymentCount % 12;
-        let yearsLabel = years === 1 ? 'year' : 'years';
-        let monthsLabel = remainingMonths === 1 ? 'month' : 'months';
-        let separatorLabel = years > 0 && remainingMonths > 0 ? ' and ' : '';
-        let payoffMessage = '';
+        var paymentCount = this.state.mortgage.paymentSchedule.length;
+        var years = Math.floor(paymentCount / 12);
+        var remainingMonths = paymentCount % 12;
+        var yearsLabel = years === 1 ? 'year' : 'years';
+        var monthsLabel = remainingMonths === 1 ? 'month' : 'months';
+        var separatorLabel = years > 0 && remainingMonths > 0 ? ' and ' : '';
+        var payoffMessage = '';
         if (years > 0) payoffMessage += `${years} ${yearsLabel}`;
         payoffMessage += separatorLabel;
         if (remainingMonths > 0) payoffMessage += `${remainingMonths} ${monthsLabel}`;


### PR DESCRIPTION
+ It has been noticed that Safari  > 9.5 does not support let keyword even after using polyfills, so further commits will be for this.