### PR TITLE
Update PaymentSchedule.js

### DIFF
--- a/src/PaymentSchedule.js
+++ b/src/PaymentSchedule.js
@@ -10,7 +10,7 @@ export default class PaymentSchedule extends React.Component {
         const styles = this.props.styles || DefaultStyles;
         const showPennies = false;
         const paymentRows = paymentSchedule.map(function(payment) {
-                let rowClass = styles.paymentRow;
+                var rowClass = styles.paymentRow;
                 const isYearlyPayment = payment.count % 12 === 0;
                 if (isYearlyPayment) {
                     rowClass += " "+styles.paymentRowYear;


### PR DESCRIPTION
+ It has been noticed that Safari  > 9.5 does not support let keyword even after using polyfills, so further commits will be for this.