### PR TITLE
Update Switch.js

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -6,7 +6,7 @@ export default class Switch extends React.Component {
     render() {
         const styles = Styles;
         const {active} = this.props;
-        let wrapperClass = styles.switchWrapper;
+        var wrapperClass = styles.switchWrapper;
         if (active) {
             wrapperClass += " "+styles.switchWrapperActive;
         }


### PR DESCRIPTION
+ It has been noticed that Safari  > 9.5 does not support let keyword even after using polyfills, so further commits will be for this.