### PR TITLE
Update Util.js

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -20,7 +20,7 @@ const percentFormatter = new Intl.NumberFormat('en-US', {
 
 export default class Util {
     static percentToValue(percent) {
-        let value = parseFloat(percent);
+        var value = parseFloat(percent);
         if (isNaN(value)) {
             return NaN;
         }
@@ -32,13 +32,13 @@ export default class Util {
 
     static moneyToValue(money) {
         if (money === undefined) return '';
-        let value = parseInt(money.replace(/\D/g, ""));
+        var value = parseInt(money.replace(/\D/g, ""));
         return !isNaN(value) ? value : '';
     }
 
     static moneyValue(amount, showPennies = false, withSymbol = true) {
         if (amount === null || amount === '') return '';
-        let value = showPennies ? penniesFormatter.format(amount) : moneyFormatter.format(amount);
+        var value = showPennies ? penniesFormatter.format(amount) : moneyFormatter.format(amount);
         if (withSymbol === false) {
             return value.substring(1);
         }
@@ -47,7 +47,7 @@ export default class Util {
 
     static percentValue(amount, withSymbol) {
         if (amount === null || amount === '') return '';
-        let value = percentFormatter.format(amount);
+        var value = percentFormatter.format(amount);
         if (withSymbol === false) {
             return value.substring(0, value.length - 1);
         }


### PR DESCRIPTION
+ It has been noticed that Safari  > 9.5 does not support let keyword even after using polyfills, so further commits will be for this.